### PR TITLE
Adding a set of forbidden and suggested functions

### DIFF
--- a/Php/ruleset.xml
+++ b/Php/ruleset.xml
@@ -76,4 +76,11 @@
    <property name="eolChar" value="\n"/>
   </properties>
  </rule>
+
+ <!-- Forbid some functions -->
+ <rule ref="Generic.PHP.ForbiddenFunctions">
+  <properties>
+   <property name="forbiddenFunctions" type="array" value="sizeof=>count,error_log=>null,var_dump=>null,dlog=>null,print_r=>null"/>
+  </properties>
+ </rule>
 </ruleset>


### PR DESCRIPTION
Have phpcs throw an error when error_log and other similar functions are called